### PR TITLE
models.py

### DIFF
--- a/django_couchdb_utils/cache/models.py
+++ b/django_couchdb_utils/cache/models.py
@@ -1,4 +1,4 @@
-from couchdb.ext.django.schema import *
+from couchdbkit.ext.django.schema import *
 from couchdbkit.exceptions import ResourceNotFound
 
 class CacheRow(Document):


### PR DESCRIPTION
Because "ImportError: No module named ext.django.schema" when use cache. 
couchdb.ext.django.schema doesn´t exists. use couchdbkit.ext.django.schema 
